### PR TITLE
fix: don't use tokenizer on config error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "llm-ls"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "home",
  "reqwest",

--- a/crates/llm-ls/Cargo.toml
+++ b/crates/llm-ls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-ls"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
- Errors on missing tokenizer file made the lsp unusable when it could just default to no tokenizer
- do tokenizer download in `tokio::spawn` so that on request cancel it continues to download the file and not leave a broken file