### PR TITLE
feat: improve logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "llm-ls"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "home",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,7 @@ dependencies = [
  "reqwest",
  "ropey",
  "serde",
+ "serde_json",
  "tokenizers",
  "tokio",
  "tower-lsp",
@@ -693,6 +694,7 @@ dependencies = [
  "tree-sitter-scala",
  "tree-sitter-swift",
  "tree-sitter-typescript",
+ "uuid",
 ]
 
 [[package]]
@@ -2036,6 +2038,17 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom",
+ "rand",
  "serde",
 ]
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@
 
 The goal of llm-ls is to provide a common platform for IDE extensions to be build on. llm-ls takes care of the heavy lifting with regards to interacting with LLMs so that extension code can be as lightweight as possible.
 
+## Features
+
+### Prompt
+
+Uses the current file as context to generate the prompt. Can use "fill in the middle" or not depending on your needs.
+
+It also makes sure that you are within the context window of the model by tokenizing the prompt.
+
+### Telemetry
+
+Gathers information about requests and completions that can enable retraining.
+
+Note that **llm-ls** does not export any data anywhere (other than setting a user agent when querying the model API), everything is stored in a log file if you set the log level to `info`.
+
+### Completion
+
+**llm-ls** parses the AST of the code to determine if completions should be multi line, single line or empty (no completion).
+
 ## Compatible extensions
 
 - [x] [llm.nvim](https://github.com/huggingface/llm.nvim)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 > [!IMPORTANT]
 > This is currently a work in progress, expect things to be broken!
 
-**llm-ls** is a LSP server leveraging LLMs for code completion (and more?).
+**llm-ls** is a LSP server leveraging LLMs to make your development experience smoother and more efficient.
+
+The goal of llm-ls is to provide a common platform for IDE extensions to be build on. llm-ls takes care of the heavy lifting with regards to interacting with LLMs so that extension code can be as lightweight as possible.
 
 ## Compatible extensions
 
@@ -12,3 +14,12 @@
 - [x] [llm-intellij](https://github.com/huggingface/llm-intellij)
 - [ ] [jupytercoder](https://github.com/bigcode-project/jupytercoder)
 
+## Roadmap
+
+- support getting context from multiple files in the workspace
+- add `suffix_percent` setting that determines the ratio of # of tokens for the prefix vs the suffix in the prompt
+- add context window fill percent or change context_window to `max_tokens`
+- filter bad suggestions (repetitive, same as below, etc)
+- support for ollama
+- support for llama.cpp
+- oltp traces ?

--- a/crates/llm-ls/Cargo.toml
+++ b/crates/llm-ls/Cargo.toml
@@ -11,6 +11,7 @@ home = "0.5"
 ropey = "1.6"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokenizers = { version = "0.13", default-features = false, features = ["onig"] }
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"] }
 tower-lsp = "0.20"
@@ -40,3 +41,10 @@ tree-sitter-scala = "0.20"
 tree-sitter-swift = "0.3"
 tree-sitter-typescript = "0.20"
 
+[dependencies.uuid]
+version = "1.4"
+features = [
+    "v4",
+    "fast-rng",
+    "serde",
+]

--- a/crates/llm-ls/Cargo.toml
+++ b/crates/llm-ls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-ls"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [[bin]]

--- a/crates/llm-ls/src/document.rs
+++ b/crates/llm-ls/src/document.rs
@@ -166,8 +166,7 @@ fn get_parser(language_id: LanguageId) -> Result<Parser> {
 }
 
 pub(crate) struct Document {
-    #[allow(dead_code)]
-    language_id: LanguageId,
+    pub(crate) language_id: LanguageId,
     pub(crate) text: Rope,
     parser: Parser,
     pub(crate) tree: Option<Tree>,

--- a/crates/llm-ls/src/language_id.rs
+++ b/crates/llm-ls/src/language_id.rs
@@ -1,6 +1,7 @@
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub(crate) enum LanguageId {
     Bash,
     C,


### PR DESCRIPTION
- add `llm-ls/acceptCompletion` & `llm-ls/rejectCompletion` routes
- generate a uuid for each request
- compute time model took to respond
- log prompt

closes #32 