### PR TITLE
Disable ropey `unicode_lines` feature

### DIFF
--- a/crates/llm-ls/Cargo.toml
+++ b/crates/llm-ls/Cargo.toml
@@ -8,7 +8,10 @@ name = "llm-ls"
 
 [dependencies]
 home = "0.5"
-ropey = "1.6"
+ropey = { version = "1.6", default-features = false, features = [
+  "simd",
+  "cr_lines",
+] }
 reqwest = { version = "0.11", default-features = false, features = [
   "json",
   "rustls-tls",


### PR DESCRIPTION
Hi! First of all, thanks a lot for open-sourcing this.

I was working on an internal fork of the project and noticed a potential issue. I have little experience with the LSP and Ropey so this might not be relevant. Anyway, here's the issue:

With the current configuration, Ropey recognises more EOL sequences than the Language Server Protocol. This mismatch can lead to errors when trying to maintain a mirror of the user's documents as the llm-ls' representation might have more lines.

See: https://docs.rs/ropey/1.6.0/ropey/index.html#a-note-about-line-breaks
See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments