### PR TITLE
Only warn of rate-limits when using HF endpoint

### DIFF
--- a/crates/llm-ls/src/adaptors.rs
+++ b/crates/llm-ls/src/adaptors.rs
@@ -200,11 +200,11 @@ fn parse_openai_text(text: &str) -> Result<Vec<Generation>, jsonrpc::Error> {
     }
 }
 
-const TGI: &str = "tgi";
-const HUGGING_FACE: &str = "huggingface";
-const OLLAMA: &str = "ollama";
-const OPENAI: &str = "openai";
-const DEFAULT_ADAPTOR: &str = HUGGING_FACE;
+pub(crate) const TGI: &str = "tgi";
+pub(crate) const HUGGING_FACE: &str = "huggingface";
+pub(crate) const OLLAMA: &str = "ollama";
+pub(crate) const OPENAI: &str = "openai";
+pub(crate) const DEFAULT_ADAPTOR: &str = HUGGING_FACE;
 
 fn unknown_adaptor_error(adaptor: Option<&String>) -> jsonrpc::Error {
     internal_error(format!("Unknown adaptor {:?}", adaptor))

--- a/crates/llm-ls/src/main.rs
+++ b/crates/llm-ls/src/main.rs
@@ -26,7 +26,7 @@ mod language_id;
 const MAX_WARNING_REPEAT: Duration = Duration::from_secs(3_600);
 pub const NAME: &str = "llm-ls";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-const HUGGINGFACE_INFERENCE_HOSTNAME: &str = "api-inference.huggingface.co";
+const HF_INFERENCE_API_HOSTNAME: &str = "api-inference.huggingface.co";
 
 fn get_position_idx(rope: &Rope, row: usize, col: usize) -> Result<usize> {
     Ok(rope.try_line_to_char(row).map_err(internal_error)?
@@ -614,7 +614,7 @@ impl Backend {
                 "received completion request for {}",
                 params.text_document_position.text_document.uri
             );
-            let is_using_hf_inference = params.adaptor.as_ref().unwrap_or(&adaptors::DEFAULT_ADAPTOR.to_string()).as_str() == adaptors::HUGGING_FACE;
+            let is_using_inference_api = params.adaptor.as_ref().unwrap_or(&adaptors::DEFAULT_ADAPTOR.to_string()).as_str() == adaptors::HUGGING_FACE;
             if params.api_token.is_none() && is_using_hf_inference {
                 let now = Instant::now();
                 let unauthenticated_warn_at = self.unauthenticated_warn_at.read().await;

--- a/crates/llm-ls/src/main.rs
+++ b/crates/llm-ls/src/main.rs
@@ -585,7 +585,7 @@ fn build_url(model: &str) -> String {
     if model.starts_with("http://") || model.starts_with("https://") {
         model.to_owned()
     } else {
-        format!("https://{HUGGINGFACE_INFERENCE_HOSTNAME}/models/{model}")
+        format!("https://{HF_INFERENCE_API_HOSTNAME}/models/{model}")
     }
 }
 
@@ -615,7 +615,7 @@ impl Backend {
                 params.text_document_position.text_document.uri
             );
             let is_using_inference_api = params.adaptor.as_ref().unwrap_or(&adaptors::DEFAULT_ADAPTOR.to_string()).as_str() == adaptors::HUGGING_FACE;
-            if params.api_token.is_none() && is_using_hf_inference {
+            if params.api_token.is_none() && is_using_inference_api {
                 let now = Instant::now();
                 let unauthenticated_warn_at = self.unauthenticated_warn_at.read().await;
                 if now.duration_since(*unauthenticated_warn_at) > MAX_WARNING_REPEAT {

--- a/crates/llm-ls/src/main.rs
+++ b/crates/llm-ls/src/main.rs
@@ -614,7 +614,7 @@ impl Backend {
                 "received completion request for {}",
                 params.text_document_position.text_document.uri
             );
-            let is_using_inference_api = params.adaptor.as_ref().unwrap_or_else(|| &adaptors::DEFAULT_ADAPTOR.to_owned()).as_str() == adaptors::HUGGING_FACE;
+            let is_using_inference_api = params.adaptor.as_ref().unwrap_or(adaptors::DEFAULT_ADAPTOR).as_str() == adaptors::HUGGING_FACE;
             if params.api_token.is_none() && is_using_inference_api {
                 let now = Instant::now();
                 let unauthenticated_warn_at = self.unauthenticated_warn_at.read().await;

--- a/crates/llm-ls/src/main.rs
+++ b/crates/llm-ls/src/main.rs
@@ -614,7 +614,7 @@ impl Backend {
                 "received completion request for {}",
                 params.text_document_position.text_document.uri
             );
-            let is_using_inference_api = params.adaptor.as_ref().unwrap_or(adaptors::DEFAULT_ADAPTOR).as_str() == adaptors::HUGGING_FACE;
+            let is_using_inference_api = params.adaptor.as_ref().unwrap_or(&adaptors::DEFAULT_ADAPTOR.to_owned()).as_str() == adaptors::HUGGING_FACE;
             if params.api_token.is_none() && is_using_inference_api {
                 let now = Instant::now();
                 let unauthenticated_warn_at = self.unauthenticated_warn_at.read().await;

--- a/crates/llm-ls/src/main.rs
+++ b/crates/llm-ls/src/main.rs
@@ -614,7 +614,7 @@ impl Backend {
                 "received completion request for {}",
                 params.text_document_position.text_document.uri
             );
-            let is_using_inference_api = params.adaptor.as_ref().unwrap_or(&adaptors::DEFAULT_ADAPTOR.to_string()).as_str() == adaptors::HUGGING_FACE;
+            let is_using_inference_api = params.adaptor.as_ref().unwrap_or_else(|| &adaptors::DEFAULT_ADAPTOR.to_owned()).as_str() == adaptors::HUGGING_FACE;
             if params.api_token.is_none() && is_using_inference_api {
                 let now = Instant::now();
                 let unauthenticated_warn_at = self.unauthenticated_warn_at.read().await;


### PR DESCRIPTION
I am trying the llm-vscode extension with llm-ls on a locally hosted endpoint (running a custom fine-tuned model), however the extension still gives a warning that I might get rate limited by HuggingFace.

Since inference doesn't run on a HuggingFace server this warning is not necessary.