### PR TITLE
Ignore documents with "output" scheme

### DIFF
--- a/crates/llm-ls/src/main.rs
+++ b/crates/llm-ls/src/main.rs
@@ -734,10 +734,19 @@ impl LanguageServer for Backend {
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri.to_string();
-        self.client
-            .log_message(MessageType::INFO, format!("{uri} changed"))
-            .await;
+        if params.content_changes.is_empty() {
+            return;
+        }
+
+        // ignore the output scheme
+        if uri.starts_with("output:") {
+            return;
+        }
+
         let mut document_map = self.document_map.write().await;
+        self.client
+            .log_message(MessageType::LOG, format!("{uri} changed"))
+            .await;
         let doc = document_map.get_mut(&uri);
         if let Some(doc) = doc {
             for change in &params.content_changes {


### PR DESCRIPTION
In the VSCode extension there is a "*" `documentFilter` set (https://github.com/huggingface/llm-vscode/blob/master/src/extension.ts#L63), which sends document did_change events for ALL updates it has e.g. when files on the filesystem changed (which will have scheme `file:` or unsaved ones `untitled`. However this also includes the VSCode "Output" tab. 

As it happens this output is coming from llm-ls itself. Whenever we log a message to the client, e.g. in 
```rust
self.client
    .log_message(MessageType::INFO, format!("{uri} changed"))
    .await;
```
the output changes and we trigger the event. This is problematic in the case of the mentioned log, since this basically triggers an infinite loop of logs and changed events. 

There are two ways to fix this:
1. setting the `documentFilter` in the VSCode client to ignore `output` scheme, I think this could look like the following:
```js
documentSelector: [{ scheme: 'file'}, {scheme: 'untitled'}],
```
The problem is there is no "negate" operator, which means we have to exhaustively list everything we want to get, and I couldn't find an enumeration.
2. just ignoring the `output` scheme. This seems like low risk, since no valuable input for code completion can get out of it anyway

Fixes https://github.com/huggingface/llm-vscode/issues/120