### PR TITLE
Fix off-by-1 error when removing from end of document

### DIFF
--- a/crates/llm-ls/src/document.rs
+++ b/crates/llm-ls/src/document.rs
@@ -237,18 +237,19 @@ impl Document {
                 },
             )
         } else {
-            let slice_size = old_end_idx - start_idx;
+            let removal_idx = self.text.try_line_to_char(range.end.line as usize).map_err(internal_error)? + (range.end.character as usize);
+            let slice_size = removal_idx - start_idx;
             self.text
-                .try_remove(start_idx..old_end_idx)
+                .try_remove(start_idx..removal_idx)
                 .map_err(internal_error)?;
             self.text.insert(start_idx, text);
             let rope = Rope::from_str(text);
             let text_len = rope.len_chars();
             let character_difference = text_len as isize - slice_size as isize;
             let new_end_idx = if character_difference.is_negative() {
-                old_end_idx - character_difference.wrapping_abs() as usize
+                removal_idx - character_difference.wrapping_abs() as usize
             } else {
-                old_end_idx + character_difference as usize
+                removal_idx + character_difference as usize
             };
             let row = self
                 .text


### PR DESCRIPTION
I encountered a bug where the in-memory document did get out of the sync with my editor, specifically the in-memory document had an additional character at the end that was previously deleted.

This happens because the deletion index was using the `get_position_idx` which caps the character of a range to the number of chars in the specific line - 1. This is usually okay, but if we delete from the end of the line the Range End is actually designated as end_char + 1. 

This resulted in one dangling character at the end when deleting from the end.

The out-of-sync lead to all kinds of underflow and range errors. I tested the change together with a local checkout of llm-vscode, which now behaves as intended when deleting from the end