### PR TITLE
Fix off-by-1 in prompt creation

### DIFF
--- a/crates/llm-ls/src/main.rs
+++ b/crates/llm-ls/src/main.rs
@@ -311,12 +311,12 @@ fn build_prompt(
         let mut after_iter = text.lines_at(pos.line as usize);
         let mut before_line = before_iter.next();
         if let Some(line) = before_line {
-            let col = (pos.character as usize).clamp(0, line.len_chars() - 1);
+            let col = (pos.character as usize).clamp(0, line.len_chars());
             before_line = Some(line.slice(0..col));
         }
         let mut after_line = after_iter.next();
         if let Some(line) = after_line {
-            let col = (pos.character as usize).clamp(0, line.len_chars() - 1);
+            let col = (pos.character as usize).clamp(0, line.len_chars());
             after_line = Some(line.slice(col..));
         }
         let mut before = vec![];
@@ -374,7 +374,7 @@ fn build_prompt(
         let mut first = true;
         for mut line in text.lines_at(pos.line as usize + 1).reversed() {
             if first {
-                let col = (pos.character as usize).clamp(0, line.len_chars() - 1);
+                let col = (pos.character as usize).clamp(0, line.len_chars());
                 line = line.slice(0..col);
                 first = false;
             }


### PR DESCRIPTION
Both for fill-in-the-middle prompts as well as normal prompts, there is a bug where we cut off one character from the input.

This happens when we are at the end of a line, e.g.

```
def hello_<CURSOR>
```

we were clamping the line column from 0 to len_chars() - 1.  However it is valid to be "behind" all the characters in a line, and thus the -1 gets us to the wrong position