### PR TITLE
Fix TGI generation parameters

### DIFF
--- a/crates/llm-ls/src/adaptors.rs
+++ b/crates/llm-ls/src/adaptors.rs
@@ -11,7 +11,13 @@ use tower_lsp::jsonrpc;
 fn build_tgi_body(prompt: String, params: &RequestParams) -> Value {
     serde_json::json!({
         "inputs": prompt,
-        "parameters": params,
+        "parameters": {
+            "max_new_tokens": params.max_new_tokens,
+            "temperature": params.temperature,
+            "do_sample": params.do_sample,
+            "top_p": params.top_p,
+            "stop_tokens": params.stop_tokens.clone()
+        },
     })
 }
 


### PR DESCRIPTION
With the move of the API to use camelCase, the request params for the TGI API are not matching anymore, since they are using a snake_case scheme according to the swagger JSON: https://huggingface.github.io/text-generation-inference/#/Text%20Generation%20Inference/generate