### PR TITLE
Use rustls-tls-native-roots to allow for OS cert stores for rustls

### DIFF
--- a/crates/llm-ls/Cargo.toml
+++ b/crates/llm-ls/Cargo.toml
@@ -16,7 +16,7 @@ ropey = { version = "1.6", default-features = false, features = [
 ] }
 reqwest = { version = "0.11", default-features = false, features = [
   "json",
-  "rustls-tls",
+  "rustls-tls-native-roots",
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
following the discussion in https://github.com/huggingface/llm-ls/issues/36#issuecomment-1771185733 I realized we can use the [rustls-tls-native-roots](https://docs.rs/reqwest/latest/reqwest/#optional-features) which says: "Enables TLS functionality provided by rustls, while using root certificates from the rustls-native-certs crate."

The [rustls-native-certs](https://github.com/rustls/rustls-native-certs/) "Integration with OS certificate stores for rustls." So it should allow for you to use the root certs from your host. Which should fix our issue from issue https://github.com/huggingface/llm-ls/issues/36.