### PR TITLE
fix: always set `return_full_text` to false for better UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "llm-ls"
-version = "0.4.0"
+version = "0.5.2"
 dependencies = [
  "clap",
  "custom-types",

--- a/crates/llm-ls/Cargo.toml
+++ b/crates/llm-ls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-ls"
-version = "0.4.0"
+version = "0.5.2"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Given that we now let the user specify every parameter that will be sent to the backend, the hardcoded `return_full_text` param we relied on using `huggingface` is unset which results in showing the start or the full prompt to the user instead of the completion.

Adding `return_full_text: false` to the request body when `backend == "huggingface" | "tgi"`.

Closes #76 