### PR TITLE
test: fix invalid deserialization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,14 +45,14 @@ jobs:
           rustflags: ''
           toolchain: nightly
 
-      - name: Install Python 3.10
-        uses: actions/setup-python@v4
+      - name: Install Python 3.12
+        uses: actions/setup-python@v5
         if: matrix.repo.python
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install node 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         if: matrix.repo.node
         with:
           node-version: 18
@@ -63,7 +63,7 @@ jobs:
           npm i -g yarn
 
       - name: Set up cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: |
@@ -93,7 +93,7 @@ jobs:
           LOG_LEVEL: ${{ github.run_attempt > 1 && 'debug' || 'info' }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: results-${{ matrix.repo.key }}
           path: ./results.json
@@ -109,67 +109,67 @@ jobs:
           apt update
           apt install -y jq
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-simple
           path: results-simple
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-picklescan
           path: results-picklescan
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-huggingface_hub
           path: results-huggingface_hub
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-fastapi
           path: results-fastapi
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-starlette
           path: results-starlette
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-lancedb
           path: results-lancedb
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-lance
           path: results-lance
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-constrandom
           path: results-constrandom
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-cached
           path: results-cached
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-async-executor
           path: results-async-executor
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-io-ts
           path: results-io-ts
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-zod
           path: results-zod
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: results-helix
           path: results-helix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,12 +83,14 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'pull_request'
         env:
           API_TOKEN: ${{ secrets.API_TOKEN }}
+          LOG_LEVEL: ${{ github.run_attempt > 1 && 'debug' || 'info' }}
 
       - name: Run testbed
         run: 'cargo run --bin testbed -r -- --api-token $API_TOKEN -f ${{ matrix.repo.name }} -p ${{ matrix.repo.parallel }}'
         if: github.event_name == 'workflow_dispatch'
         env:
           API_TOKEN: ${{ secrets.API_TOKEN }}
+          LOG_LEVEL: ${{ github.run_attempt > 1 && 'debug' || 'info' }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,11 @@ jobs:
           rustflags: ''
           toolchain: nightly
 
-      - name: Install Python 3.12
+      - name: Install Python 3.10
         uses: actions/setup-python@v5
         if: matrix.repo.python
         with:
-          python-version: '3.12'
+          python-version: '3.10'
 
       - name: Install node 18
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           - { name: tiangolo/fastapi, key: fastapi, parallel: 8, node: false, python: true }
           - { name: encode/starlette, key: starlette, parallel: 8, node: false, python: true }
           - { name: lancedb/lancedb, key: lancedb, parallel: 2, node: false, python: false }
-          - { name: lancedb/lance, key: lance, parallel: 2, node: false, python: false }
+          # - { name: lancedb/lance, key: lance, parallel: 2, node: false, python: false }
           - { name: tkaitchuck/constrandom, key: constrandom, parallel: 8, node: false, python: false }
           - { name: jaemk/cached, key: cached, parallel: 4, node: false, python: false }
           - { name: smol-rs/async-executor, key: async-executor, parallel: 4, node: false, python: false }
@@ -139,10 +139,10 @@ jobs:
           name: results-lancedb
           path: results-lancedb
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: results-lance
-          path: results-lance
+      # - uses: actions/download-artifact@v4
+      #   with:
+      #     name: results-lance
+      #     path: results-lance
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,19 +14,19 @@ jobs:
     strategy:
       matrix:
         repo:
-          - { name: simple, key: simple, parallel: 8 }
-          - { name: mmaitre314/picklescan, key: picklescan, parallel: 8 }
-          - { name: huggingface/huggingface_hub, key: huggingface_hub, parallel: 8 }
-          - { name: tiangolo/fastapi, key: fastapi, parallel: 8 }
-          - { name: encode/starlette, key: starlette, parallel: 8 }
-          - { name: lancedb/lancedb, key: lancedb, parallel: 2 }
-          - { name: lancedb/lance, key: lance, parallel: 2 }
-          - { name: tkaitchuck/constrandom, key: constrandom, parallel: 8 }
-          - { name: jaemk/cached, key: cached, parallel: 4 }
-          - { name: smol-rs/async-executor, key: async-executor, parallel: 4 }
-          - { name: gcanti/io-ts, key: io-ts, parallel: 8 }
-          - { name: colinhacks/zod, key: zod, parallel: 8 }
-          - { name: helix-editor/helix, key: helix, parallel: 2 }
+          - { name: simple, key: simple, parallel: 8, node: false, python: false }
+          - { name: mmaitre314/picklescan, key: picklescan, parallel: 8, node: false, python: true }
+          - { name: huggingface/huggingface_hub, key: huggingface_hub, parallel: 8, node: false, python: true }
+          - { name: tiangolo/fastapi, key: fastapi, parallel: 8, node: false, python: true }
+          - { name: encode/starlette, key: starlette, parallel: 8, node: false, python: true }
+          - { name: lancedb/lancedb, key: lancedb, parallel: 2, node: false, python: false }
+          - { name: lancedb/lance, key: lance, parallel: 2, node: false, python: false }
+          - { name: tkaitchuck/constrandom, key: constrandom, parallel: 8, node: false, python: false }
+          - { name: jaemk/cached, key: cached, parallel: 4, node: false, python: false }
+          - { name: smol-rs/async-executor, key: async-executor, parallel: 4, node: false, python: false }
+          - { name: gcanti/io-ts, key: io-ts, parallel: 8, node: true, python: false }
+          - { name: colinhacks/zod, key: zod, parallel: 8, node: true, python: false }
+          - { name: helix-editor/helix, key: helix, parallel: 2, node: false, python: false }
     runs-on: [self-hosted, intel-cpu, 8-cpu, ci]
     container:
       image: ubuntu:22.04
@@ -47,15 +47,18 @@ jobs:
 
       - name: Install Python 3.10
         uses: actions/setup-python@v4
+        if: matrix.repo.python
         with:
           python-version: '3.10'
 
       - name: Install node 18
         uses: actions/setup-node@v3
+        if: matrix.repo.node
         with:
           node-version: 18
 
       - name: Install yarn
+        if: matrix.repo.node
         run: |
           npm i -g yarn
 

--- a/crates/lsp-client/src/msg.rs
+++ b/crates/lsp-client/src/msg.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt::{self, Display},
     io,
-    marker::Unpin,
 };
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};

--- a/crates/testbed/repositories-ci.yaml
+++ b/crates/testbed/repositories-ci.yaml
@@ -30,7 +30,7 @@ repositories:
       type: github
       owner: mmaitre314
       name: picklescan
-      revision: 40001cd1caa9e041b1bce1b80f3707056cd8be52
+      revision: 108b06040de644c7aeb5f22d8b10dd9c5d282386
       src_path: src/picklescan
     build_command: picklescan-venv/bin/python3
     build_args: ["-m", "compileall", "-q", "."]
@@ -39,6 +39,7 @@ repositories:
     runner_command: picklescan-venv/bin/python3
     setup_commands:
       - ["python3", ["-m", "venv", "picklescan-venv"]]
+      - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "setuptools"]]
       - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "."]]
       - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "-r", "requirements.txt"]]
     holes_file: picklescan-smol.json

--- a/crates/testbed/repositories-ci.yaml
+++ b/crates/testbed/repositories-ci.yaml
@@ -203,7 +203,7 @@ repositories:
       type: github
       owner: helix-editor
       name: helix
-      revision: a1272bdb17a63361342a318982e46129d558743c
+      revision: cdef4f8a701f921c29fdfe66f104a2edac7fe05c
       exclude_paths:
         - .cargo
         - .github

--- a/crates/testbed/repositories-ci.yaml
+++ b/crates/testbed/repositories-ci.yaml
@@ -201,9 +201,9 @@ repositories:
     holes_file: zod-smol.json
   - source:
       type: github
-      owner: helix-editor
+      owner: McPatate
       name: helix
-      revision: cdef4f8a701f921c29fdfe66f104a2edac7fe05c
+      revision: 01c1ebebd813c9034059a966fae2bbc487b1a69f
       exclude_paths:
         - .cargo
         - .github

--- a/crates/testbed/repositories-ci.yaml
+++ b/crates/testbed/repositories-ci.yaml
@@ -39,7 +39,6 @@ repositories:
     runner_command: picklescan-venv/bin/python3
     setup_commands:
       - ["python3", ["-m", "venv", "picklescan-venv"]]
-      - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "setuptools"]]
       - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "."]]
       - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "-r", "requirements.txt"]]
     holes_file: picklescan-smol.json

--- a/crates/testbed/repositories.yaml
+++ b/crates/testbed/repositories.yaml
@@ -203,7 +203,7 @@ repositories:
       type: github
       owner: helix-editor
       name: helix
-      revision: a1272bdb17a63361342a318982e46129d558743c
+      revision: cdef4f8a701f921c29fdfe66f104a2edac7fe05c
       exclude_paths:
         - .cargo
         - .github

--- a/crates/testbed/repositories.yaml
+++ b/crates/testbed/repositories.yaml
@@ -30,7 +30,7 @@ repositories:
       type: github
       owner: mmaitre314
       name: picklescan
-      revision: 40001cd1caa9e041b1bce1b80f3707056cd8be52
+      revision: 108b06040de644c7aeb5f22d8b10dd9c5d282386
       src_path: src/picklescan
     build_command: picklescan-venv/bin/python3
     build_args: ["-m", "compileall", "-q", "."]
@@ -39,6 +39,7 @@ repositories:
     runner_command: picklescan-venv/bin/python3
     setup_commands:
       - ["python3", ["-m", "venv", "picklescan-venv"]]
+      - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "setuptools"]]
       - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "."]]
       - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "-r", "requirements.txt"]]
     holes_file: picklescan.json

--- a/crates/testbed/repositories.yaml
+++ b/crates/testbed/repositories.yaml
@@ -39,7 +39,6 @@ repositories:
     runner_command: picklescan-venv/bin/python3
     setup_commands:
       - ["python3", ["-m", "venv", "picklescan-venv"]]
-      - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "setuptools"]]
       - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "."]]
       - ["picklescan-venv/bin/python3", ["-m", "pip", "install", "-r", "requirements.txt"]]
     holes_file: picklescan.json

--- a/crates/testbed/repositories.yaml
+++ b/crates/testbed/repositories.yaml
@@ -201,9 +201,9 @@ repositories:
     holes_file: zod.json
   - source:
       type: github
-      owner: helix-editor
+      owner: McPatate
       name: helix
-      revision: cdef4f8a701f921c29fdfe66f104a2edac7fe05c
+      revision: 01c1ebebd813c9034059a966fae2bbc487b1a69f
       exclude_paths:
         - .cargo
         - .github

--- a/crates/testbed/src/main.rs
+++ b/crates/testbed/src/main.rs
@@ -198,6 +198,7 @@ struct RepositoriesConfig {
     context_window: usize,
     fim: FimParams,
     model: String,
+    #[serde(flatten)]
     backend: Backend,
     repositories: Vec<Repository>,
     tls_skip_verify_insecure: bool,


### PR DESCRIPTION
- fix invalid repositories file deserialization
- install node & python only when needed in ci
- log stdout & stderr of setup & build commands in debug
- update actions to node 20
- when an action is re-run, set `LOG_LEVEL` to debug
- use helix fork because of ahash version https://github.com/helix-editor/helix/pull/9666
- disable lance because of simd nightly features not being available anymore