### PR TITLE
feat: add `cohere` backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Note that **llm-ls** does not export any data anywhere (other than setting a use
 
 ### Multiple backends
 
-**llm-ls** is compatible with Hugging Face's [Inference API](https://huggingface.co/docs/api-inference/en/index), Hugging Face's [text-generation-inference](https://github.com/huggingface/text-generation-inference), [ollama](https://github.com/ollama/ollama) and OpenAI compatible APIs, like the [python llama.cpp server bindings](https://github.com/abetlen/llama-cpp-python?tab=readme-ov-file#openai-compatible-web-server).
+**llm-ls** is compatible with Hugging Face's [Inference API](https://huggingface.co/docs/api-inference/en/index), Hugging Face's [text-generation-inference](https://github.com/huggingface/text-generation-inference), [Cohere](https://docs.cohere.com/reference/chat), [ollama](https://github.com/ollama/ollama) and OpenAI compatible APIs, like the [python llama.cpp server bindings](https://github.com/abetlen/llama-cpp-python?tab=readme-ov-file#openai-compatible-web-server).
 
 ## Compatible extensions
 

--- a/crates/custom-types/src/llm_ls.rs
+++ b/crates/custom-types/src/llm_ls.rs
@@ -63,6 +63,9 @@ fn hf_default_url() -> String {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase", tag = "backend")]
 pub enum Backend {
+    Cohere {
+        url: String,
+    },
     HuggingFace {
         #[serde(default = "hf_default_url", deserialize_with = "parse_url")]
         url: String,
@@ -99,6 +102,7 @@ impl Backend {
 
     pub fn url(self) -> String {
         match self {
+            Self::Cohere { url } => url,
             Self::HuggingFace { url } => url,
             Self::LlamaCpp { url } => url,
             Self::Ollama { url } => url,

--- a/crates/llm-ls/src/error.rs
+++ b/crates/llm-ls/src/error.rs
@@ -33,6 +33,8 @@ pub enum Error {
     InvalidRepositoryId,
     #[error("invalid tokenizer path")]
     InvalidTokenizerPath,
+    #[error("cohere error: {0}")]
+    Cohere(crate::backend::CohereError),
     #[error("llama.cpp error: {0}")]
     LlamaCpp(crate::backend::APIError),
     #[error("ollama error: {0}")]

--- a/crates/llm-ls/src/main.rs
+++ b/crates/llm-ls/src/main.rs
@@ -428,6 +428,23 @@ fn build_url(backend: Backend, model: &str, disable_url_path_completion: bool) -
     }
 
     match backend {
+        Backend::Cohere { mut url } => {
+            if url.ends_with("/v1/chat") {
+                url
+            } else if url.ends_with("/v1/") {
+                url.push_str("chat");
+                url
+            } else if url.ends_with("/v1") {
+                url.push_str("/chat");
+                url
+            } else if url.ends_with('/') {
+                url.push_str("v1/chat");
+                url
+            } else {
+                url.push_str("/v1/chat");
+                url
+            }
+        }
         Backend::HuggingFace { url } => format!("{url}/models/{model}"),
         Backend::LlamaCpp { mut url } => {
             if url.ends_with("/completions") {


### PR DESCRIPTION
Hello! 👋 

This adds support for Cohere. API Reference: [docs.cohere.com/reference/chat](https://docs.cohere.com/reference/chat)

I have not done a lot of experimentation yet, but it requires a custom `preamble` to work well for code completion since the default is design to be an assistant, it's a little too chatty. So far this is what I tested with:

```
You are a software engineer. Complete the code. Do not repeat the given code. Do not explain.
```

If this PR is accepted, I will document it and other default parameters in the editor extensions.

_Disclaimer:_ I am a Cohere employee experimenting with the product, this is in no way indicates that Cohere will provide official support for llm-ls. 🙂