### PR TITLE
feat: added api key support to ollama backend.

### DIFF
--- a/crates/llm-ls/src/backend.rs
+++ b/crates/llm-ls/src/backend.rs
@@ -118,8 +118,8 @@ enum OllamaAPIResponse {
     Error(APIError),
 }
 
-fn build_ollama_headers() -> HeaderMap {
-    HeaderMap::new()
+fn build_ollama_headers(api_token: Option<&String>, ide: Ide) -> Result<HeaderMap> {
+    build_api_headers(api_token, ide)
 }
 
 fn parse_ollama_text(text: &str) -> Result<Vec<Generation>> {
@@ -243,7 +243,7 @@ pub(crate) fn build_headers(
     match backend {
         Backend::HuggingFace { .. } => build_api_headers(api_token, ide),
         Backend::LlamaCpp { .. } => Ok(build_llamacpp_headers()),
-        Backend::Ollama { .. } => Ok(build_ollama_headers()),
+        Backend::Ollama { .. } => build_ollama_headers(api_token, ide),
         Backend::OpenAi { .. } => build_openai_headers(api_token, ide),
         Backend::Tgi { .. } => build_tgi_headers(api_token, ide),
     }


### PR DESCRIPTION
This PR adds api key support to the ollama backend. Ollama itself does not support any authentication (as far as I know), but it can easily be added by a reverse proxy or other software like Open WebUI, which proxies the ollama queries.

I tested against my local Open WebUI instance using http://myhost/ollama URL and seems to be working fine, in fact much better than raw ollama (I'm getting a lot of errors loading the model, though it already is loaded). This PR allows me to control access to my server using open webui and not to expose publicly the ollama instance.

Closes issue #106 .