### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
@@ -80,7 +80,7 @@ jobs:
         run: cargo xtask dist
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: dist-${{ matrix.target }}
           path: ./dist
@@ -102,7 +102,7 @@ jobs:
         run: apk add --no-cache git clang lld musl-dev nodejs npm openssl-dev pkgconfig g++
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
@@ -110,7 +110,7 @@ jobs:
         run: cargo xtask dist
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: dist-x86_64-unknown-linux-musl
           path: ./dist
@@ -121,7 +121,7 @@ jobs:
     needs: ["dist", "dist-x86_64-unknown-linux-musl"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
@@ -134,39 +134,39 @@ jobs:
         id: split
         run: echo "tag=${BRANCH##*/}" >> $GITHUB_OUTPUT
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist-aarch64-apple-darwin
           path: dist
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist-x86_64-apple-darwin
           path: dist
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist-x86_64-unknown-linux-gnu
           path: dist
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist-x86_64-unknown-linux-musl
           path: dist
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist-aarch64-unknown-linux-gnu
           path: dist
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist-arm-unknown-linux-gnueabihf
           path: dist
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist-x86_64-pc-windows-msvc
           path: dist
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist-i686-pc-windows-msvc
           path: dist
-      # - uses: actions/download-artifact@v4
+      # - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
       #   with:
       #     name: dist-aarch64-pc-windows-msvc
       #     path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       image: ubuntu:22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install dependencies
         run: |
@@ -41,16 +41,16 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt install -y pkg-config protobuf-compiler libssl-dev curl build-essential git-all gfortran
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         if: matrix.repo.python
         with:
           python-version: '3.10'
 
       - name: Install node 18
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         if: matrix.repo.node
         with:
           node-version: 18
@@ -61,7 +61,7 @@ jobs:
           npm i -g yarn
 
       - name: Set up cargo cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         continue-on-error: false
         with:
           path: |
@@ -94,7 +94,7 @@ jobs:
           LOG_LEVEL: ${{ github.run_attempt > 1 && 'debug' || 'info' }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: results-${{ matrix.repo.key }}
           path: ./results.json
@@ -111,67 +111,67 @@ jobs:
           apt update
           apt install -y jq
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-simple
           path: results-simple
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-picklescan
           path: results-picklescan
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-huggingface_hub
           path: results-huggingface_hub
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-fastapi
           path: results-fastapi
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-starlette
           path: results-starlette
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-lancedb
           path: results-lancedb
 
-      # - uses: actions/download-artifact@v4
+      # - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
       #   with:
       #     name: results-lance
       #     path: results-lance
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-constrandom
           path: results-constrandom
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-cached
           path: results-cached
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-async-executor
           path: results-async-executor
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-io-ts
           path: results-io-ts
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-zod
           path: results-zod
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: results-helix
           path: results-helix
@@ -196,7 +196,7 @@ jobs:
           EOF
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1  # v2
         id: fc
         if: github.event_name == 'pull_request'
         with:
@@ -206,7 +206,7 @@ jobs:
 
       - name: Create or update comment
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2  # v3
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `test.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `test.yml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `test.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `test.yml` | `actions/setup-node` | `v4` | `v4` | `49933ea5288c…` |
| `test.yml` | `actions/cache` | `v4` | `v4` | `0057852bfaa8…` |
| `test.yml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `test.yml` | `peter-evans/find-comment` | `v2` | `v2` | `a54c31d7fa09…` |
| `test.yml` | `peter-evans/create-or-update-comment` | `v3` | `v3` | `23ff15729ef2…` |
| `release.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `release.yml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `release.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `release.yml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `release.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `release.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `release.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `release.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `release.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `release.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `release.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `release.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `release.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `release.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#167